### PR TITLE
Update samsung_keyboard_mitmproxy_exploit.py

### DIFF
--- a/samsung_keyboard_mitmproxy_exploit.py
+++ b/samsung_keyboard_mitmproxy_exploit.py
@@ -1,5 +1,5 @@
 import os
-from libmproxy import proxy, flow
+from mitmproxy import proxy, flow
 import copy
 import json
 import time


### PR DESCRIPTION
mitmproxy officially renamed the Python package from libmproxy to mitmproxy.
